### PR TITLE
Fix gain controls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ impl<MODE> HackRfOne<MODE> {
         if gain > 40 {
             Err(Error::Argument)
         } else {
-            let buf: [u8; 1] = self.read_control(Request::SetLnaGain, gain & !0x07, 0)?;
+            let buf: [u8; 1] = self.read_control(Request::SetLnaGain, 0, gain & !0x07)?;
             if buf[0] == 0 {
                 Err(Error::Argument)
             } else {
@@ -492,7 +492,7 @@ impl<MODE> HackRfOne<MODE> {
         if gain > 62 {
             Err(Error::Argument)
         } else {
-            let buf: [u8; 1] = self.read_control(Request::SetVgaGain, gain & !0b1, 0)?;
+            let buf: [u8; 1] = self.read_control(Request::SetVgaGain, 0, gain & !0b1)?;
             if buf[0] == 0 {
                 Err(Error::Argument)
             } else {
@@ -508,7 +508,7 @@ impl<MODE> HackRfOne<MODE> {
         if gain > 47 {
             Err(Error::Argument)
         } else {
-            let buf: [u8; 1] = self.read_control(Request::SetTxvgaGain, gain, 0)?;
+            let buf: [u8; 1] = self.read_control(Request::SetTxvgaGain, 0, gain)?;
             if buf[0] == 0 {
                 Err(Error::Argument)
             } else {


### PR DESCRIPTION
It appears that the gain values actually go into the `index` parameter of `read_control`, not `value` (see original libhackrf code, e.g. https://github.com/mossmann/hackrf/blob/master/host/libhackrf/src/hackrf.c#L1453 )

This PR fixes it for LNA, VGA and TXVGA controls.